### PR TITLE
Fixed langchain version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "ctransformers>=0.2.25,<0.3.0",
         "deepmerge>=1.1.0,<2.0.0",
         "InstructorEmbedding>=1.0.1,<2.0.0",
-        "langchain>=0.0.181,<0.0.292",
+        "langchain>=0.0.181,<0.0.293",
         "pydantic>=1.9,<2.0",
         "pyyaml>=6.0",
         "quart>=0.18.3,<0.19.0",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "ctransformers>=0.2.25,<0.3.0",
         "deepmerge>=1.1.0,<2.0.0",
         "InstructorEmbedding>=1.0.1,<2.0.0",
-        "langchain>=0.0.181",
+        "langchain>=0.0.181,<0.0.292",
         "pydantic>=1.9,<2.0",
         "pyyaml>=6.0",
         "quart>=0.18.3,<0.19.0",


### PR DESCRIPTION
Change of import path of Embeddings in langchain in the latest version - 0.0.293

```
- from langchain.embeddings.base import Embeddings
+ from langchain.schema.embeddings import Embeddings
```
References

- https://github.com/langchain-ai/langchain/releases/tag/v0.0.293

- https://github.com/langchain-ai/langchain/pull/10696/files

Fixed by adding a condition to limit langchain version to 0.0.292